### PR TITLE
Avoid `@octokit/rest` warning about the require

### DIFF
--- a/lib/grizzly.js
+++ b/lib/grizzly.js
@@ -3,7 +3,7 @@
 const {promisify} = require('util');
 
 const path = require('path');
-const Octokit = require('@octokit/rest');
+const Octokit = require('@octokit/rest').Octokit;
 const log = require('debug')('grizzly');
 const readjson = promisify(require('readjson'));
 


### PR DESCRIPTION
```
[@octokit/rest] `const Octokit = require("@octokit/rest")` is deprecated. Use `const { Octokit } = require("@octokit/rest")` instead
```